### PR TITLE
Unit test clean

### DIFF
--- a/alter_orq.py
+++ b/alter_orq.py
@@ -279,6 +279,93 @@ class Load(luigi.Task):
         return luigi.LocalTarget(output_path)
 
 #-----------------------------------------------------------------------------------------------------------------------------
+# ======================================================
+# Pruebas unitarias clean
+# ======================================================
+from src.utils.metadatos_utils import C_testing_clean_columns,C_testing_clean_rangos
+from src.utils.metadatos_utils import Linaje_clean_columns_testing, Linaje_clean_rangos_testing
+
+from testing.test_clean_columns import Test_Columns_Case
+from testing.test_clean_rangos import Test_Ranges_Case
+
+MetadatosCleanColumnTesting = Linaje_clean_columns_testing()
+
+class CleanColumn_Testing(luigi.Task):
+    '''
+    Prueba unitaria de número de columnas correctas en clean.rita
+    '''
+    # def requires(self):
+    #     return Extraction()
+
+    # Recolectamos fecha y usuario para metadatos a partir de fecha actual
+    MetadatosCleanColumnTesting.fecha =  datetime.now()
+    MetadatosCleanColumnTesting.usuario = getpass.getuser()
+
+    def run(self):
+        
+        
+        unit_test_cleancolumns = Test_Columns_Case()
+        unit_test_cleancolumns.test_that_all_columns_are_present()
+
+    def output(self):
+        return
+
+@CleanColumn_Testing.event_handler(Event.SUCCESS)
+def on_success(self):
+    MetadatosCleanColumnTesting.ip_ec2 = ""
+    MetadatosCleanColumnTesting.task_status ="Successful"
+    print(MetadatosCleanColumnTesting.to_upsert())
+    C_testing_clean_columns(MetadatosCleanColumnTesting.to_upsert())
+
+@CleanColumn_Testing.event_handler(Event.FAILURE)
+def on_failure(self,exception):
+    MetadatosCleanColumnTesting.ip_ec2 = "Número de columnas no coincide"
+    MetadatosCleanColumnTesting.task_status ="Failure"
+    print(MetadatosCleanColumnTesting.to_upsert())
+    C_testing_clean_columns(MetadatosCleanColumnTesting.to_upsert())
+
+
+
+MetadatosCleanRangoTesting = Linaje_clean_rangos_testing()
+class CleanRango_Testing(luigi.Task):
+    '''
+    Prueba unitaria levels de columna rangoatrasohoras de clean son 
+    los correctos
+    '''
+    # def requires(self):
+    #     return Extraction()
+
+    # Recolectamos fecha y usuario para metadatos a partir de fecha actual
+    MetadatosCleanRangoTesting.fecha =  datetime.now()
+    MetadatosCleanRangoTesting.usuario = getpass.getuser()
+
+    def run(self):        
+        unit_test_cleanrangos = Test_Ranges_Case()
+        unit_test_cleanrangos.test_that_all_ranges_are_present()
+
+    def output(self):
+        return
+
+@CleanRango_Testing.event_handler(Event.SUCCESS)
+def on_success(self):
+    MetadatosCleanRangoTesting.ip_ec2 = ""
+    MetadatosCleanRangoTesting.task_status ="Successful"
+    print(MetadatosCleanRangoTesting.to_upsert())
+    C_testing_clean_rangos(MetadatosCleanRangoTesting.to_upsert())
+
+@CleanRango_Testing.event_handler(Event.FAILURE)
+def on_failure(self,exception):
+    MetadatosCleanRangoTesting.ip_ec2 = "levels no coinciden"
+    MetadatosCleanRangoTesting.task_status ="Failure"
+    print(MetadatosCleanRangoTesting.to_upsert())
+    C_testing_clean_rangos(MetadatosCleanRangoTesting.to_upsert())
+
+
+
+
+# ======================================================
+# Limpieza de datos
+# ======================================================
 # Limpiar DATOS
 CURRENT_DIR = os.getcwd()
 

--- a/clean_luigi.py
+++ b/clean_luigi.py
@@ -1,0 +1,112 @@
+# PYTHONPATH='.' luigi --module clean_luigi CleanColumn_Testing --local-scheduler
+# PYTHONPATH='.' luigi --module clean_luigi CleanRango_Testing --local-scheduler
+
+###  Librerias necesarias
+import luigi
+import luigi.contrib.s3
+from luigi import Event, Task, build # Utilidades para acciones tras un task exitoso o fallido
+from luigi.contrib.postgres import CopyToTable,PostgresQuery
+import boto3
+from datetime import date, datetime
+import getpass # Usada para obtener el usuario
+from io import BytesIO
+import socket #import publicip
+import requests
+import os, subprocess, ast
+import pandas as pd
+import psycopg2
+from psycopg2 import extras
+from zipfile import ZipFile
+from pathlib import Path
+import os
+
+###  Imports desde directorio de proyecto dpa_rita
+## Credenciales
+from src import(
+MY_USER,
+MY_PASS,
+MY_HOST,
+MY_PORT,
+MY_DB,
+)
+
+from src.utils.metadatos_utils import C_testing_clean_columns,C_testing_clean_rangos
+from src.utils.metadatos_utils import Linaje_clean_columns_testing, Linaje_clean_rangos_testing
+
+from testing.test_clean_columns import Test_Columns_Case
+from testing.test_clean_rangos import Test_Ranges_Case
+
+MetadatosCleanColumnTesting = Linaje_clean_columns_testing()
+
+class CleanColumn_Testing(luigi.Task):
+    '''
+    Prueba unitaria de número de columnas correctas en clean.rita
+    '''
+    # def requires(self):
+    #     return Extraction()
+
+    # Recolectamos fecha y usuario para metadatos a partir de fecha actual
+    MetadatosCleanColumnTesting.fecha =  datetime.now()
+    MetadatosCleanColumnTesting.usuario = getpass.getuser()
+
+    def run(self):
+        
+        
+        unit_test_cleancolumns = Test_Columns_Case()
+        unit_test_cleancolumns.test_that_all_columns_are_present()
+
+    def output(self):
+        return
+
+@CleanColumn_Testing.event_handler(Event.SUCCESS)
+def on_success(self):
+    MetadatosCleanColumnTesting.ip_ec2 = ""
+    MetadatosCleanColumnTesting.task_status ="Successful"
+    print(MetadatosCleanColumnTesting.to_upsert())
+    C_testing_clean_columns(MetadatosCleanColumnTesting.to_upsert())
+
+@CleanColumn_Testing.event_handler(Event.FAILURE)
+def on_failure(self,exception):
+    MetadatosCleanColumnTesting.ip_ec2 = "Número de columnas no coincide"
+    MetadatosCleanColumnTesting.task_status ="Failure"
+    print(MetadatosCleanColumnTesting.to_upsert())
+    C_testing_clean_columns(MetadatosCleanColumnTesting.to_upsert())
+
+
+
+MetadatosCleanRangoTesting = Linaje_clean_rangos_testing()
+class CleanRango_Testing(luigi.Task):
+    '''
+    Prueba unitaria levels de columna rangoatrasohoras de clean son 
+    los correctos
+    '''
+    # def requires(self):
+    #     return Extraction()
+
+    # Recolectamos fecha y usuario para metadatos a partir de fecha actual
+    MetadatosCleanRangoTesting.fecha =  datetime.now()
+    MetadatosCleanRangoTesting.usuario = getpass.getuser()
+
+    def run(self):
+       
+        
+        unit_test_cleanrangos = Test_Ranges_Case()
+        unit_test_cleanrangos.test_that_all_ranges_are_present()
+
+    def output(self):
+        return
+
+@CleanRango_Testing.event_handler(Event.SUCCESS)
+def on_success(self):
+    MetadatosCleanRangoTesting.ip_ec2 = ""
+    MetadatosCleanRangoTesting.task_status ="Successful"
+    print(MetadatosCleanRangoTesting.to_upsert())
+    C_testing_clean_rangos(MetadatosCleanRangoTesting.to_upsert())
+
+@CleanRango_Testing.event_handler(Event.FAILURE)
+def on_failure(self,exception):
+    MetadatosCleanRangoTesting.ip_ec2 = "levels no coinciden"
+    MetadatosCleanRangoTesting.task_status ="Failure"
+    print(MetadatosCleanRangoTesting.to_upsert())
+    C_testing_clean_rangos(MetadatosCleanRangoTesting.to_upsert())
+

--- a/src/utils/metadatos_utils.py
+++ b/src/utils/metadatos_utils.py
@@ -104,6 +104,35 @@ class Linaje_load_testing():
     def to_upsert(self):
         return (self.fecha, self.nombre_task, self.usuario,\
          self.ip_ec2, self.year, self.month, self.task_status)
+
+
+  # Clase para reunir los metadatos del testing de clean columns
+class Linaje_clean_columns_testing():
+    def __init__(self, fecha=0, nombre_task=0, usuario=0, ip_ec2=0, task_status=0):
+        self.fecha = fecha # time stamp
+        self.nombre_task = self.__class__.__name__#nombre_task
+        self.usuario = usuario # Usuario de la maquina de GNU/Linux que corre la instancia
+        self.ip_ec2 = ip_ec2 #Corresponde a la dirección IP desde donde se ejecuto la tarea
+        self.task_status = "Failure" # estatus de ejecución: Fallido, exitoso, etc.
+
+    def to_upsert(self):
+        return (self.fecha, self.nombre_task, self.usuario,\
+         self.ip_ec2, self.task_status)
+
+# Clase para reunir los metadatos del testing de clean rangos
+class Linaje_clean_rangos_testing():
+    def __init__(self, fecha=0, nombre_task=0, usuario=0, ip_ec2=0, task_status=0):
+        self.fecha = fecha # time stamp
+        self.nombre_task = self.__class__.__name__#nombre_task
+        self.usuario = usuario # Usuario de la maquina de GNU/Linux que corre la instancia
+        self.ip_ec2 = ip_ec2 #Corresponde a la dirección IP desde donde se ejecuto la tarea
+        self.task_status = "Failure" # estatus de ejecución: Fallido, exitoso, etc.
+
+    def to_upsert(self):
+        return (self.fecha, self.nombre_task, self.usuario,\
+         self.ip_ec2, self.task_status)
+
+
   
 # ==========================================
 # Funciones para insertar metadatos a RDS
@@ -345,6 +374,51 @@ def EL_testing_load(record_to_insert):
     connection.close()
 
     return print("metadatos.testing_load insertion Done - PostgreSQL connection is closed")
+
+def C_testing_clean_columns(record_to_insert):
+    '''
+    Funcion auxiliar para insertar a metadatos.testing_clean_columns
+    '''
+    # Conexion y cursor para query
+    connection = psycopg2.connect(user = MY_USER, # Usuario RDS
+                                 password = MY_PASS, # password de usuario de RDS
+                                 host = MY_HOST,# endpoint
+                                 port="5432", # cambiar por el puerto
+                                 database=MY_DB) # Nombre de la base de datos
+    cursor = connection.cursor()
+
+    # Query para insertar metadatos
+    postgres_insert_query = """ INSERT INTO metadatos.testing_clean_columns ( fecha,\
+    nombre_task, usuario, ip_ec2, task_status) VALUES ( %s, %s, %s, %s, %s) """
+    cursor.execute(postgres_insert_query, record_to_insert)
+    connection.commit()
+    cursor.close()
+    connection.close()
+
+    return print("metadatos.testing_clean_columns insertion Done - PostgreSQL connection is closed")
+
+def C_testing_clean_rangos(record_to_insert):
+    '''
+    Funcion auxiliar para insertar a metadatos.testing_clean_rangos
+    '''
+    # Conexion y cursor para query
+    connection = psycopg2.connect(user = MY_USER, # Usuario RDS
+                                 password = MY_PASS, # password de usuario de RDS
+                                 host = MY_HOST,# endpoint
+                                 port="5432", # cambiar por el puerto
+                                 database=MY_DB) # Nombre de la base de datos
+    cursor = connection.cursor()
+
+    # Query para insertar metadatos
+    postgres_insert_query = """ INSERT INTO metadatos.testing_clean_rangos ( fecha,\
+    nombre_task, usuario, ip_ec2, task_status) VALUES ( %s, %s, %s, %s, %s) """
+    cursor.execute(postgres_insert_query, record_to_insert)
+    connection.commit()
+    cursor.close()
+    connection.close()
+
+    return print("metadatos.testing_clean_rangos insertion Done - PostgreSQL connection is closed")
+
 
 def clean_metadata_rds(record_to_insert):
     '''

--- a/src/utils/sql/crear_tablas.sql
+++ b/src/utils/sql/crear_tablas.sql
@@ -81,6 +81,30 @@ CREATE TABLE IF NOT EXISTS metadatos.testing_load(
 
 GRANT ALL ON  metadatos.testing_load to postgres;
 
+-- Crea tabla metadatos.testing_clean_columns
+
+CREATE TABLE IF NOT EXISTS metadatos.testing_clean_columns(
+  fecha VARCHAR,
+  nombre_task VARCHAR,
+  usuario VARCHAR,
+  ip_ec2 VARCHAR,
+  task_status VARCHAR
+);
+
+GRANT ALL ON  metadatos.testing_clean_columns to postgres;
+
+-- Crea tabla metadatos.testing_clean_columns
+
+CREATE TABLE IF NOT EXISTS metadatos.testing_clean_rangos(
+  fecha VARCHAR,
+  nombre_task VARCHAR,
+  usuario VARCHAR,
+  ip_ec2 VARCHAR,
+  task_status VARCHAR
+);
+
+GRANT ALL ON  metadatos.testing_clean_rangos to postgres;
+
 --- Crea tabla metadatos.semantic
 
 --DROP TABLE IF EXISTS metadatos.semantic;

--- a/testing/test_clean_columns.py
+++ b/testing/test_clean_columns.py
@@ -1,4 +1,5 @@
 #python -m marbles test_clean_columns.py
+#python -m marbles testing/test_clean_columns.py
 
 import unittest
 from marbles.mixins import mixins
@@ -8,7 +9,7 @@ from pyspark.sql import SparkSession
 import psycopg2 as pg
 import pandas as pd
 from pyspark.sql.types import StructType, StructField, StringType
-from src.features.build_features import get_clean_data
+from src.features.build_features import get_raw_data, clean, get_clean_data
 import socket
 from src.utils.metadatos_utils import Linaje_clean_data, clean_metadata_rds
 from src import(
@@ -20,15 +21,13 @@ MY_DB,
 )
 
 class Test_Columns_Case(unittest.TestCase, mixins.CategoricalMixins):
-	
-    '''
-    
+	'''
     Verifica que la cantidad de columnas en clean.rita 
     sean las esperadas
 
     '''
-	def test_that_all_columns_are_present(self):		
+
+	def test_that_all_columns_are_present(self):
 		df_clean = clean().limit(10)
 		clean_rita	= get_clean_data().limit(10)
 		self.assertEqual(len(df_clean.columns), len(clean_rita.columns))
-

--- a/testing/test_clean_columns.py
+++ b/testing/test_clean_columns.py
@@ -20,16 +20,14 @@ MY_DB,
 )
 
 class Test_Columns_Case(unittest.TestCase, mixins.CategoricalMixins):
+	
     '''
     
     Verifica que la cantidad de columnas en clean.rita 
     sean las esperadas
 
     '''
-
-	def test_that_all_columns_are_present(self):
-
-
+	def test_that_all_columns_are_present(self):		
 		df_clean = clean().limit(10)
 		clean_rita	= get_clean_data().limit(10)
 		self.assertEqual(len(df_clean.columns), len(clean_rita.columns))


### PR DESCRIPTION
- En alter_orq estan las 2 pruebas de unit testing de clean, ya las probe y corren bien
- En src.utils.metadatos_utils existen Linaje_clean_columns_testing, Linaje_clean_rangos_testing
clases para reunir los metadatos del testing de extract
- En src.utils.metadatos_utils existen  C_testing_clean_columns,C_testing_clean_rangos
 Funciones auxiliares para insertar a metadatos.testing_clean_columns y metadatos.testing_clean_rangos  respectivamente.
- En src.utils.sql.crear_tablas existen las tablas metadatos.testing_clean_columns y metadatos.testing_clean_rangos